### PR TITLE
[README] Fix the language for the Podfile syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Integration
 
 Using CocoaPods 0.36, it is possible to integrate SwiftHamcrest using a Podfile similar to this:
 
-```swift
+```ruby
 target 'HamcrestDemoTests' do
   pod 'SwiftHamcrest'
 end


### PR DESCRIPTION
The quotes were displayed as erroneous on https://cocoapods.org/pods/SwiftHamcrest#integration.
