### PR TITLE
Make sample Podfile more precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,10 @@ Integration
 Integrate SwiftHamcrest using a Podfile similar to this:
 
 ```ruby
-target 'HamcrestDemoTests' do
-  pod 'SwiftHamcrest'
+use_frameworks!
+
+target 'HamcrestDemoTests', :exclusive => true do
+  pod 'SwiftHamcrest', '~> 0.3'
 end
 ```
 


### PR DESCRIPTION
A few issues with the sample Podfile:
- Have to specify `use_frameworks!` for Swift pod
- Restrict it to test test target
- Specify version. If you adopt semantic versioning #9, this will update minor versions but not compatibility-breaking major version changes.
