### PR TITLE
Make describeMismatch public

### DIFF
--- a/Hamcrest/Descriptions.swift
+++ b/Hamcrest/Descriptions.swift
@@ -30,7 +30,7 @@ func describeErrorMismatch<T>(_ error: T, _ description: String, _ mismatchDescr
     return "GOT ERROR: " + describeActualValue(error, mismatchDescription) + ", EXPECTED ERROR: \(description)"
 }
 
-func describeMismatch<T>(_ value: T, _ description: String, _ mismatchDescription: String?) -> String {
+public func describeMismatch<T>(_ value: T, _ description: String, _ mismatchDescription: String?) -> String {
     return "GOT: " + describeActualValue(value, mismatchDescription) + ", EXPECTED: \(description)"
 }
 


### PR DESCRIPTION
So that matchers are useful outside of `assertThat`.

I'm giving a talk at try!Swift Tokyo 2017, showing how Hamcrest matchers are useful for making mock objects.