### PR TITLE
More SwiftFormat rules:

### DIFF
--- a/Hamcrest.xcodeproj/project.pbxproj
+++ b/Hamcrest.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantNilInit,redundantParens,redundantReturn,redundantSelf,spaceAroundBraces,spaceAroundOperators,spaceInsideBraces,trailingCommas,unusedArguments,void ${SRCROOT}\n";
+			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,trailingCommas,unusedArguments,void ${SRCROOT}\n";
 		};
 		481906251ED69B6500E47930 /* Swift Format */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Hamcrest/Descriptions.swift
+++ b/Hamcrest/Descriptions.swift
@@ -35,7 +35,7 @@ public func describeMismatch<T>(_ value: T, _ description: String, _ mismatchDes
 }
 
 func describeActualValue<T>(_ value: T, _ mismatchDescription: String?) -> String {
-    return describe(value) + (mismatchDescription.map{" (\($0))"} ?? "")
+    return describe(value) + (mismatchDescription.map {" (\($0))"} ?? "")
 }
 
 func joinDescriptions(_ descriptions: [String]) -> String {
@@ -57,7 +57,7 @@ func joinMatcherDescriptions<S: Sequence, T>(_ matchers: S, prefix: String = "al
 }
 
 private func joinStrings(_ strings: [String]) -> String {
-    switch (strings.count) {
+    switch strings.count {
     case 1:
         return strings[0]
     default:

--- a/Hamcrest/Hamcrest.swift
+++ b/Hamcrest/Hamcrest.swift
@@ -8,8 +8,8 @@ import XCTest
 public var HamcrestReportFunction: (_: String, _ file: StaticString, _ line: UInt) -> () = HamcrestDefaultReportFunction
 public let HamcrestDefaultReportFunction =
     isPlayground()
-        ? {(message, file, line) in}
-        : {(message, file, line) in XCTFail(message, file: file, line: line)}
+        ? {message, file, line in}
+        : {message, file, line in XCTFail(message, file: file, line: line)}
 
 // MARK: helpers
 

--- a/Hamcrest/MetaMatchers.swift
+++ b/Hamcrest/MetaMatchers.swift
@@ -22,7 +22,7 @@ public func allOf<S: Sequence, T>(_ matchers: S) -> Matcher<T> where S.Iterator.
             switch delegateMatching(value, matcher, {
                 (mismatchDescription: String?) -> String? in
                 "mismatch: \(matcher.description)"
-                    + (mismatchDescription.map{" (\($0))"} ?? "")
+                    + (mismatchDescription.map {" (\($0))"} ?? "")
             }) {
             case let .mismatch(mismatchDescription):
                 mismatchDescriptions.append(mismatchDescription)

--- a/Hamcrest/OperatorMatchers.swift
+++ b/Hamcrest/OperatorMatchers.swift
@@ -11,7 +11,7 @@ public struct MatchResultDescription {
     }
 
     init<T>(value: @autoclosure () -> T, matcher: Matcher<T>) {
-        self.result = applyMatcher(matcher, toValue: value)
+        result = applyMatcher(matcher, toValue: value)
     }
 }
 

--- a/Hamcrest/SequenceMatchers.swift
+++ b/Hamcrest/SequenceMatchers.swift
@@ -25,7 +25,7 @@ public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>)
         for value in values {
             switch delegateMatching(value, matcher, {
                 (mismatchDescription: String?) -> String? in
-                "mismatch: \(value)" + (mismatchDescription.map{" (\($0))"} ?? "")
+                "mismatch: \(value)" + (mismatchDescription.map {" (\($0))"} ?? "")
             }) {
             case let .mismatch(mismatchDescription):
                 mismatchDescriptions.append(mismatchDescription)

--- a/HamcrestDemoTests/HamcrestDemoTests.swift
+++ b/HamcrestDemoTests/HamcrestDemoTests.swift
@@ -5,7 +5,7 @@ class HamcrestDemoTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        HamcrestReportFunction = {(message, file, line) in XCTFail(message, file:file, line:line)}
+        HamcrestReportFunction = {message, file, line in XCTFail(message, file:file, line:line)}
     }
 
     // Look at README.playground for a tutorial.

--- a/HamcrestTests/BaseTestCase.swift
+++ b/HamcrestTests/BaseTestCase.swift
@@ -3,10 +3,10 @@ import Hamcrest
 
 class BaseTestCase: XCTestCase {
 
-    var reportedError: String? = nil
+    var reportedError: String?
 
     override func setUp() {
-        HamcrestReportFunction = {(message, file, line) in self.reportedError = message}
+        HamcrestReportFunction = {message, file, line in self.reportedError = message}
         super.setUp()
     }
 
@@ -66,7 +66,7 @@ class BaseTestCase: XCTestCase {
 private func expectedMessage(_ value: Any, _ description: String, mismatchDescription: String?)
     -> String {
 
-    let inset = (mismatchDescription.map{" (\($0))"} ?? "")
+    let inset = (mismatchDescription.map {" (\($0))"} ?? "")
     return "GOT: \(valueDescription(value))\(inset), EXPECTED: \(description)"
 }
 
@@ -81,7 +81,7 @@ private func valueDescription(_ value: Any) -> String {
 }
 
 private func joinStrings(_ strings: [String]) -> String {
-    switch (strings.count) {
+    switch strings.count {
     case 0:
         return "none"
     case 1:


### PR DESCRIPTION
redundantNilInit
redundantParens
redundantSelf
spaceAroundBraces

I don't think these will be controversial, but @renep feel free to push back on anything you don't like.
…There will probably rules _after_ these that we'll have to make decisions on whether to adopt.