### PR TITLE
Enable SwiftFormat rule "blankLinesAtStartOfScope"

### DIFF
--- a/Hamcrest.xcodeproj/project.pbxproj
+++ b/Hamcrest.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/swiftformat --disable blankLinesAtStartOfScope,indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
+			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
 		};
 		481906251ED69B6500E47930 /* Swift Format */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Hamcrest/DictionaryMatchers.swift
+++ b/Hamcrest/DictionaryMatchers.swift
@@ -1,6 +1,5 @@
 public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>)
     -> Matcher<Dictionary<K, V>> {
-
         return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") {
             (dictionary: Dictionary<K, V>) -> Bool in
 
@@ -15,7 +14,6 @@ public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>)
 
 public func hasEntry<K, V: Equatable>(_ expectedKey: K, _ expectedValue: V)
     -> Matcher<Dictionary<K, V>> {
-
         return hasEntry(equalToWithoutDescription(expectedKey), equalToWithoutDescription(expectedValue))
 }
 
@@ -25,7 +23,6 @@ public func hasKey<K, V>(_ matcher: Matcher<K>) -> Matcher<Dictionary<K, V>> {
 
 public func hasKey<K, V>(_ expectedKey: K)
     -> Matcher<Dictionary<K, V>> {
-
         return hasKey(equalToWithoutDescription(expectedKey))
 }
 

--- a/Hamcrest/Hamcrest.swift
+++ b/Hamcrest/Hamcrest.swift
@@ -95,7 +95,6 @@ func isPlayground() -> Bool {
 
 func reportResult(_ possibleResult: String?, file: StaticString = #file, line: UInt = #line)
     -> String {
-
     if let result = possibleResult {
         HamcrestReportFunction(result, file, line)
         return result

--- a/Hamcrest/MatchResult.swift
+++ b/Hamcrest/MatchResult.swift
@@ -1,5 +1,4 @@
 public enum MatchResult: ExpressibleByBooleanLiteral {
-
     case match
     case mismatch(String?)
 

--- a/Hamcrest/Matcher.swift
+++ b/Hamcrest/Matcher.swift
@@ -1,5 +1,4 @@
 public struct Matcher<T> {
-
     public let description: String
     let f: (T) -> MatchResult
 

--- a/Hamcrest/OperatorMatchers.swift
+++ b/Hamcrest/OperatorMatchers.swift
@@ -41,7 +41,6 @@ public func <= <T: Comparable>(value: T, expectedValue: T) -> MatchResultDescrip
 
 public func && (lhs: MatchResultDescription, rhs: MatchResultDescription)
     -> MatchResultDescription {
-
     switch (lhs.result, rhs.result) {
     case (nil, nil):
         return MatchResultDescription(result: .none)

--- a/Hamcrest/SequenceMatchers.swift
+++ b/Hamcrest/SequenceMatchers.swift
@@ -18,7 +18,6 @@ public func hasCount<T: Collection>(_ expectedCount: T.IndexDistance) -> Matcher
 
 public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>)
     -> Matcher<S> where S.Iterator.Element == T {
-
     return Matcher("a sequence where every item \(matcher.description)") {
         (values: S) -> MatchResult in
         var mismatchDescriptions: [String?] = []
@@ -49,7 +48,6 @@ private func hasItem<T, S: Sequence>(_ matcher: Matcher<T>,
 
 public func hasItem<T, S: Sequence>(_ matcher: Matcher<T>)
     -> Matcher<S> where S.Iterator.Element == T {
-
     return Matcher("a sequence containing \(matcher.description)") {
         (values: S) -> Bool in hasItem(matcher, values)
     }
@@ -57,13 +55,11 @@ public func hasItem<T, S: Sequence>(_ matcher: Matcher<T>)
 
 public func hasItem<T: Equatable, S: Sequence>(_ expectedValue: T)
     -> Matcher<S> where S.Iterator.Element == T {
-
     return hasItem(equalToWithoutDescription(expectedValue))
 }
 
 private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>])
     -> Matcher<S> where S.Iterator.Element == T {
-
     return Matcher("a sequence containing \(joinMatcherDescriptions(matchers))") {
         (values: S) -> MatchResult in
         var missingItems = [] as [Matcher<T>]
@@ -85,19 +81,16 @@ private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>])
 
 public func hasItems<T, S: Sequence>(_ matchers: Matcher<T>...)
     -> Matcher<S> where S.Iterator.Element == T {
-
     return hasItems(matchers)
 }
 
 public func hasItems<T: Equatable, S: Sequence>
     (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
-
     return hasItems(expectedValues.map {equalToWithoutDescription($0)})
 }
 
 private func contains<T, S: Sequence>(_ matchers: [Matcher<T>])
     -> Matcher<S> where S.Iterator.Element == T {
-
     return Matcher("a sequence containing " + joinDescriptions(matchers.map({$0.description}))) {
         (values: S) -> MatchResult in
         return applyMatchers(matchers, values: values)
@@ -106,19 +99,16 @@ private func contains<T, S: Sequence>(_ matchers: [Matcher<T>])
 
 public func contains<T, S: Sequence>(_ matchers: Matcher<T>...)
     -> Matcher<S> where S.Iterator.Element == T {
-
     return contains(matchers)
 }
 
 public func contains<T: Equatable, S: Sequence>
     (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
-
     return contains(expectedValues.map {equalToWithoutDescription($0)})
 }
 
 private func containsInAnyOrder<T, S: Sequence>
     (_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
-
     let descriptions = joinDescriptions(matchers.map({$0.description}))
 
     return Matcher("a sequence containing in any order " + descriptions) {
@@ -150,19 +140,16 @@ private func containsInAnyOrder<T, S: Sequence>
 
 public func containsInAnyOrder<T, S: Sequence>
     (_ matchers: Matcher<T>...) -> Matcher<S> where S.Iterator.Element == T {
-
     return containsInAnyOrder(matchers)
 }
 
 public func containsInAnyOrder<T: Equatable, S: Sequence>
     (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
-
     return containsInAnyOrder(expectedValues.map {equalToWithoutDescription($0)})
 }
 
 func applyMatchers<T, S: Sequence>
     (_ matchers: [Matcher<T>], values: S) -> MatchResult where S.Iterator.Element == T {
-
     var mismatchDescriptions: [String?] = []
 
     var i = 0

--- a/HamcrestDemo-macOS/AppDelegate.swift
+++ b/HamcrestDemo-macOS/AppDelegate.swift
@@ -9,7 +9,6 @@
 import Cocoa
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-
     @IBOutlet weak var window: NSWindow!
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {

--- a/HamcrestDemo/AppDelegate.swift
+++ b/HamcrestDemo/AppDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {

--- a/HamcrestDemo/ViewController.swift
+++ b/HamcrestDemo/ViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class ViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.

--- a/HamcrestDemoTests-macOS/HamcrestDemoTests.swift
+++ b/HamcrestDemoTests-macOS/HamcrestDemoTests.swift
@@ -3,7 +3,6 @@ import Hamcrest
 import XCTest
 
 class HamcrestDemoTests: XCTestCase {
-
     // Look at README.playground for a tutorial.
 
     func testSuccess() {

--- a/HamcrestDemoTests/HamcrestDemoTests.swift
+++ b/HamcrestDemoTests/HamcrestDemoTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class HamcrestDemoTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         HamcrestReportFunction = {message, file, line in XCTFail(message, file:file, line:line)}

--- a/HamcrestTests/ArithmeticMatcherTests.swift
+++ b/HamcrestTests/ArithmeticMatcherTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class ArithmeticMatcherTests: BaseTestCase {
-
     func testEqualTo() {
         assertMatch(5, equalTo(5))
         assertMismatch(5, equalTo(10), "equal to 10")

--- a/HamcrestTests/AssertThatTests.swift
+++ b/HamcrestTests/AssertThatTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class AssertThatTests: BaseTestCase {
-
     func testMatcherWithBoolReturningTrue() {
         let matcher = Matcher<Int>("") {value in true}
 

--- a/HamcrestTests/BaseTestCase.swift
+++ b/HamcrestTests/BaseTestCase.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class BaseTestCase: XCTestCase {
-
     var reportedError: String?
 
     override func setUp() {
@@ -25,7 +24,6 @@ class BaseTestCase: XCTestCase {
     func assertMismatch<T>(_ value: T, _ matcher: Matcher<T>, _ description: String,
                            mismatchDescription: String? = nil,
                            file: StaticString = #file, line: UInt = #line) {
-
         reportedError = nil
         assertThat(value, matcher)
         if let mismatchDescription = mismatchDescription {
@@ -38,7 +36,6 @@ class BaseTestCase: XCTestCase {
     func assertMismatch<T>(_ value: [T], _ matcher: Matcher<[T]>, _ description: String,
                            mismatchDescription: String? = nil,
                            file: StaticString = #file, line: UInt = #line) {
-
         reportedError = nil
         assertThat(value, matcher)
         if let mismatchDescription = mismatchDescription {
@@ -65,7 +62,6 @@ class BaseTestCase: XCTestCase {
 
 private func expectedMessage(_ value: Any, _ description: String, mismatchDescription: String?)
     -> String {
-
     let inset = (mismatchDescription.map {" (\($0))"} ?? "")
     return "GOT: \(valueDescription(value))\(inset), EXPECTED: \(description)"
 }

--- a/HamcrestTests/BasicMatcherTests.swift
+++ b/HamcrestTests/BasicMatcherTests.swift
@@ -12,7 +12,6 @@ private func address<T: AnyObject>(_ object: T) -> String {
 }
 
 class BasicMatcherTests: BaseTestCase {
-
     func testAnything() {
         assertMatch(5, anything())
     }

--- a/HamcrestTests/DictionaryMatcherTests.swift
+++ b/HamcrestTests/DictionaryMatcherTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class DictionaryMatcherTests: BaseTestCase {
-
     let dictionary = [
         "key1": "value1",
         "key2": "value2",

--- a/HamcrestTests/ErrorTests.swift
+++ b/HamcrestTests/ErrorTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class ErrorTests: BaseTestCase {
-
     func testThrownError() {
         let matcher = Matcher<Int>("") {value in true}
 

--- a/HamcrestTests/MatchResultTests.swift
+++ b/HamcrestTests/MatchResultTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class MatchResultTests: XCTestCase {
-
     func testInitBooleanLiteralTrue() {
         let matchResult: MatchResult = true
 

--- a/HamcrestTests/MatcherMocks.swift
+++ b/HamcrestTests/MatcherMocks.swift
@@ -3,7 +3,6 @@ import XCTest
 
 func succeedingMatcher<T: Equatable>(_ expectingValue: T, description: String = "description",
                                      file: StaticString = #file, line: UInt = #line) -> Matcher<T> {
-
     return Matcher<T>(description) {
         (value: T) -> Bool in
         XCTAssertEqual(value, expectingValue, file: file, line: line)
@@ -13,13 +12,11 @@ func succeedingMatcher<T: Equatable>(_ expectingValue: T, description: String = 
 
 func succeedingMatcher<T>(_ type: T.Type = T.self, description: String = "description")
     -> Matcher<T> {
-
     return Matcher<T>(description) {value in true}
 }
 
 func failingMatcher<T>(_ type: T.Type = T.self, description: String = "description",
                        mismatchDescription: String? = nil) -> Matcher<T> {
-
     return Matcher<T>(description) {value in .mismatch(mismatchDescription)}
 }
 

--- a/HamcrestTests/MetaMatcherTests.swift
+++ b/HamcrestTests/MetaMatcherTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class MetaMatcherTests: BaseTestCase {
-
     func testIs() {
         assertMatch(5, `is`(succeedingMatcher()))
         assertMismatch(5, `is`(failingMatcher()), "is description")

--- a/HamcrestTests/OperatorMatcherTests.swift
+++ b/HamcrestTests/OperatorMatcherTests.swift
@@ -12,7 +12,6 @@ private func address<T: AnyObject>(_ object: T) -> String {
 }
 
 class OperatorMatcherTests: BaseTestCase {
-
     func testSameInstance() {
         let object = SampleClass()
         assertThat(object === object)

--- a/HamcrestTests/ReflectionMatcherTests.swift
+++ b/HamcrestTests/ReflectionMatcherTests.swift
@@ -8,7 +8,6 @@ private class ReflectableClass {
 }
 
 class ReflectionMatcherTests: BaseTestCase {
-
     fileprivate let instance = ReflectableClass()
 
     func testHasProperty() {

--- a/HamcrestTests/SequenceMatcherTests.swift
+++ b/HamcrestTests/SequenceMatcherTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class SequenceMatcherTests: BaseTestCase {
-
     let sequence = ["item1", "item2", "item3"]
 
     func testEmpty() {

--- a/HamcrestTests/StringMatcherTests.swift
+++ b/HamcrestTests/StringMatcherTests.swift
@@ -2,7 +2,6 @@ import Hamcrest
 import XCTest
 
 class StringTests: BaseTestCase {
-
     let string = "foobar"
 
     func testContainsString() {


### PR DESCRIPTION
This is a purely stylistic change from the way Rene wrote this. I think most Swift folks prefer less vertical white space.
But we don't have to do this. If you don't like it, it's not worth it.