### PR TITLE
Make formatting more like common Swift

### DIFF
--- a/Hamcrest.xcodeproj/project.pbxproj
+++ b/Hamcrest.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/swiftformat --disable blankLinesAtStartOfScope,indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
+			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Hamcrest/ArithmeticMatchers.swift
+++ b/Hamcrest/ArithmeticMatchers.swift
@@ -3,8 +3,7 @@ public func equalTo<T: Equatable>(_ expectedValue: T) -> Matcher<T> {
 }
 
 public func closeTo(_ expectedValue: Double, _ delta: Double) -> Matcher<Double> {
-    return Matcher("within \(delta) of \(expectedValue)") {
-        (value: Double) -> MatchResult in
+    return Matcher("within \(delta) of \(expectedValue)") { (value: Double) -> MatchResult in
         let actual = abs(value - expectedValue)
         return MatchResult(actual < delta, "difference of \(actual)")
     }

--- a/Hamcrest/BasicMatchers.swift
+++ b/Hamcrest/BasicMatchers.swift
@@ -3,8 +3,7 @@ public func anything<T>() -> Matcher<T> {
 }
 
 public func sameInstance<T: AnyObject>(_ expectedValue: T) -> Matcher<T> {
-    return Matcher("same instance as \(describeAddress(expectedValue))") {
-        (value: T) -> MatchResult in
+    return Matcher("same instance as \(describeAddress(expectedValue))") { (value: T) -> MatchResult in
         value === expectedValue ? .match : .mismatch(describeAddress(value))
     }
 }
@@ -12,8 +11,7 @@ public func sameInstance<T: AnyObject>(_ expectedValue: T) -> Matcher<T> {
 // MARK: is
 
 public func `is`<T>(_ matcher: Matcher<T>) -> Matcher<T> {
-    return Matcher("is " + matcher.description) {
-        (value: T) -> MatchResult in
+    return Matcher("is " + matcher.description) { (value: T) -> MatchResult in
         return matcher.matches(value)
     }
 }
@@ -37,8 +35,7 @@ public func present<T>() -> Matcher<Optional<T>> {
 }
 
 public func presentAnd<T>(_ matcher: Matcher<T>) -> Matcher<Optional<T>> {
-    return Matcher("present and \(matcher.description)") {
-        (value: T?) -> MatchResult in
+    return Matcher("present and \(matcher.description)") { (value: T?) -> MatchResult in
         if let unwrappedValue = value {
             return matcher.matches(unwrappedValue)
         } else {
@@ -59,8 +56,7 @@ public func instanceOf<T: Any>(_ expectedType: T.Type, and matcher: Matcher<T>) 
 }
 
 public func instanceOfAnd<T: Any>(_ matcher: Matcher<T>) -> Matcher<Any> {
-    return Matcher("instance of \(T.self) and \(matcher.description)") {
-        (value: Any) -> MatchResult in
+    return Matcher("instance of \(T.self) and \(matcher.description)") { (value: Any) -> MatchResult in
         if let value = value as? T {
             return matcher.matches(value)
         } else {

--- a/Hamcrest/DictionaryMatchers.swift
+++ b/Hamcrest/DictionaryMatchers.swift
@@ -1,5 +1,4 @@
-public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>)
-    -> Matcher<Dictionary<K, V>> {
+public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>) -> Matcher<Dictionary<K, V>> {
         return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") {
             (dictionary: Dictionary<K, V>) -> Bool in
 
@@ -12,8 +11,7 @@ public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>)
         }
 }
 
-public func hasEntry<K, V: Equatable>(_ expectedKey: K, _ expectedValue: V)
-    -> Matcher<Dictionary<K, V>> {
+public func hasEntry<K, V: Equatable>(_ expectedKey: K, _ expectedValue: V) -> Matcher<Dictionary<K, V>> {
         return hasEntry(equalToWithoutDescription(expectedKey), equalToWithoutDescription(expectedValue))
 }
 
@@ -21,8 +19,7 @@ public func hasKey<K, V>(_ matcher: Matcher<K>) -> Matcher<Dictionary<K, V>> {
     return hasEntry(matcher, anything())
 }
 
-public func hasKey<K, V>(_ expectedKey: K)
-    -> Matcher<Dictionary<K, V>> {
+public func hasKey<K, V>(_ expectedKey: K) -> Matcher<Dictionary<K, V>> {
         return hasKey(equalToWithoutDescription(expectedKey))
 }
 

--- a/Hamcrest/DictionaryMatchers.swift
+++ b/Hamcrest/DictionaryMatchers.swift
@@ -1,16 +1,16 @@
 public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>) -> Matcher<Dictionary<K, V>> {
-        return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") { (dictionary: Dictionary<K, V>) -> Bool in
-            for (key, value) in dictionary {
-                if keyMatcher.matches(key).boolValue && valueMatcher.matches(value).boolValue {
-                    return true
-                }
+    return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") { (dictionary: Dictionary<K, V>) -> Bool in
+        for (key, value) in dictionary {
+            if keyMatcher.matches(key).boolValue && valueMatcher.matches(value).boolValue {
+                return true
             }
-            return false
         }
+        return false
+    }
 }
 
 public func hasEntry<K, V: Equatable>(_ expectedKey: K, _ expectedValue: V) -> Matcher<Dictionary<K, V>> {
-        return hasEntry(equalToWithoutDescription(expectedKey), equalToWithoutDescription(expectedValue))
+    return hasEntry(equalToWithoutDescription(expectedKey), equalToWithoutDescription(expectedValue))
 }
 
 public func hasKey<K, V>(_ matcher: Matcher<K>) -> Matcher<Dictionary<K, V>> {
@@ -18,7 +18,7 @@ public func hasKey<K, V>(_ matcher: Matcher<K>) -> Matcher<Dictionary<K, V>> {
 }
 
 public func hasKey<K, V>(_ expectedKey: K) -> Matcher<Dictionary<K, V>> {
-        return hasKey(equalToWithoutDescription(expectedKey))
+    return hasKey(equalToWithoutDescription(expectedKey))
 }
 
 public func hasValue<K, V>(_ matcher: Matcher<V>) -> Matcher<Dictionary<K, V>> {

--- a/Hamcrest/DictionaryMatchers.swift
+++ b/Hamcrest/DictionaryMatchers.swift
@@ -1,7 +1,5 @@
 public func hasEntry<K, V>(_ keyMatcher: Matcher<K>, _ valueMatcher: Matcher<V>) -> Matcher<Dictionary<K, V>> {
-        return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") {
-            (dictionary: Dictionary<K, V>) -> Bool in
-
+        return Matcher("a dictionary containing [\(keyMatcher.description) -> \(valueMatcher.description)]") { (dictionary: Dictionary<K, V>) -> Bool in
             for (key, value) in dictionary {
                 if keyMatcher.matches(key).boolValue && valueMatcher.matches(value).boolValue {
                     return true

--- a/Hamcrest/MetaMatchers.swift
+++ b/Hamcrest/MetaMatchers.swift
@@ -15,12 +15,10 @@ public func allOf<T>(_ matchers: Matcher<T>...) -> Matcher<T> {
 }
 
 public func allOf<S: Sequence, T>(_ matchers: S) -> Matcher<T> where S.Iterator.Element == Matcher<T> {
-    return Matcher(joinMatcherDescriptions(matchers)) {
-        (value: T) -> MatchResult in
+    return Matcher(joinMatcherDescriptions(matchers)) { (value: T) -> MatchResult in
         var mismatchDescriptions: [String?] = []
         for matcher in matchers {
-            switch delegateMatching(value, matcher, {
-                (mismatchDescription: String?) -> String? in
+            switch delegateMatching(value, matcher, { (mismatchDescription: String?) -> String? in
                 "mismatch: \(matcher.description)"
                     + (mismatchDescription.map {" (\($0))"} ?? "")
             }) {
@@ -43,8 +41,7 @@ public func anyOf<T>(_ matchers: Matcher<T>...) -> Matcher<T> {
 }
 
 public func anyOf<S: Sequence, T>(_ matchers: S) -> Matcher<T> where S.Iterator.Element == Matcher<T> {
-    return Matcher(joinMatcherDescriptions(matchers, prefix: "any of")) {
-        (value: T) -> MatchResult in
+    return Matcher(joinMatcherDescriptions(matchers, prefix: "any of")) { (value: T) -> MatchResult in
         let matchedMatchers = matchers.filter {$0.matches(value).boolValue}
         return MatchResult(!matchedMatchers.isEmpty)
     }

--- a/Hamcrest/OperatorMatchers.swift
+++ b/Hamcrest/OperatorMatchers.swift
@@ -39,8 +39,7 @@ public func <= <T: Comparable>(value: T, expectedValue: T) -> MatchResultDescrip
     return MatchResultDescription(value: value, matcher: lessThanOrEqualTo(expectedValue))
 }
 
-public func && (lhs: MatchResultDescription, rhs: MatchResultDescription)
-    -> MatchResultDescription {
+public func && (lhs: MatchResultDescription, rhs: MatchResultDescription) -> MatchResultDescription {
     switch (lhs.result, rhs.result) {
     case (nil, nil):
         return MatchResultDescription(result: .none)

--- a/Hamcrest/ReflectionMatchers.swift
+++ b/Hamcrest/ReflectionMatchers.swift
@@ -1,6 +1,5 @@
 public func hasProperty<T, U>(_ propertyMatcher: Matcher<String>, _ matcher: Matcher<U>) -> Matcher<T> {
-    return Matcher("has property \(propertyMatcher.description) with value \(matcher.description)") {
-        (value: T) -> MatchResult in
+    return Matcher("has property \(propertyMatcher.description) with value \(matcher.description)") { (value: T) -> MatchResult in
         if let propertyValue = getProperty(value, keyMatcher: propertyMatcher) {
             if let propertyValue = propertyValue as? U {
                 return delegateMatching(propertyValue, matcher) {

--- a/Hamcrest/SequenceMatchers.swift
+++ b/Hamcrest/SequenceMatchers.swift
@@ -16,8 +16,7 @@ public func hasCount<T: Collection>(_ expectedCount: T.IndexDistance) -> Matcher
     return hasCount(equalToWithoutDescription(expectedCount))
 }
 
-public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>)
-    -> Matcher<S> where S.Iterator.Element == T {
+public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>) -> Matcher<S> where S.Iterator.Element == T {
     return Matcher("a sequence where every item \(matcher.description)") {
         (values: S) -> MatchResult in
         var mismatchDescriptions: [String?] = []
@@ -36,8 +35,7 @@ public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>)
     }
 }
 
-private func hasItem<T, S: Sequence>(_ matcher: Matcher<T>,
-                                                                        _ values: S) -> Bool where S.Iterator.Element == T {
+private func hasItem<T, S: Sequence>(_ matcher: Matcher<T>, _ values: S) -> Bool where S.Iterator.Element == T {
     for value in values {
         if matcher.matches(value).boolValue {
             return true
@@ -46,20 +44,17 @@ private func hasItem<T, S: Sequence>(_ matcher: Matcher<T>,
     return false
 }
 
-public func hasItem<T, S: Sequence>(_ matcher: Matcher<T>)
-    -> Matcher<S> where S.Iterator.Element == T {
+public func hasItem<T, S: Sequence>(_ matcher: Matcher<T>) -> Matcher<S> where S.Iterator.Element == T {
     return Matcher("a sequence containing \(matcher.description)") {
         (values: S) -> Bool in hasItem(matcher, values)
     }
 }
 
-public func hasItem<T: Equatable, S: Sequence>(_ expectedValue: T)
-    -> Matcher<S> where S.Iterator.Element == T {
+public func hasItem<T: Equatable, S: Sequence>(_ expectedValue: T) -> Matcher<S> where S.Iterator.Element == T {
     return hasItem(equalToWithoutDescription(expectedValue))
 }
 
-private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>])
-    -> Matcher<S> where S.Iterator.Element == T {
+private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
     return Matcher("a sequence containing \(joinMatcherDescriptions(matchers))") {
         (values: S) -> MatchResult in
         var missingItems = [] as [Matcher<T>]
@@ -79,36 +74,30 @@ private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>])
     }
 }
 
-public func hasItems<T, S: Sequence>(_ matchers: Matcher<T>...)
-    -> Matcher<S> where S.Iterator.Element == T {
+public func hasItems<T, S: Sequence>(_ matchers: Matcher<T>...) -> Matcher<S> where S.Iterator.Element == T {
     return hasItems(matchers)
 }
 
-public func hasItems<T: Equatable, S: Sequence>
-    (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
+public func hasItems<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
     return hasItems(expectedValues.map {equalToWithoutDescription($0)})
 }
 
-private func contains<T, S: Sequence>(_ matchers: [Matcher<T>])
-    -> Matcher<S> where S.Iterator.Element == T {
+private func contains<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
     return Matcher("a sequence containing " + joinDescriptions(matchers.map({$0.description}))) {
         (values: S) -> MatchResult in
         return applyMatchers(matchers, values: values)
     }
 }
 
-public func contains<T, S: Sequence>(_ matchers: Matcher<T>...)
-    -> Matcher<S> where S.Iterator.Element == T {
+public func contains<T, S: Sequence>(_ matchers: Matcher<T>...) -> Matcher<S> where S.Iterator.Element == T {
     return contains(matchers)
 }
 
-public func contains<T: Equatable, S: Sequence>
-    (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
+public func contains<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
     return contains(expectedValues.map {equalToWithoutDescription($0)})
 }
 
-private func containsInAnyOrder<T, S: Sequence>
-    (_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
+private func containsInAnyOrder<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
     let descriptions = joinDescriptions(matchers.map({$0.description}))
 
     return Matcher("a sequence containing in any order " + descriptions) {
@@ -138,18 +127,15 @@ private func containsInAnyOrder<T, S: Sequence>
     }
 }
 
-public func containsInAnyOrder<T, S: Sequence>
-    (_ matchers: Matcher<T>...) -> Matcher<S> where S.Iterator.Element == T {
+public func containsInAnyOrder<T, S: Sequence>(_ matchers: Matcher<T>...) -> Matcher<S> where S.Iterator.Element == T {
     return containsInAnyOrder(matchers)
 }
 
-public func containsInAnyOrder<T: Equatable, S: Sequence>
-    (_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
+public func containsInAnyOrder<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Matcher<S> where S.Iterator.Element == T {
     return containsInAnyOrder(expectedValues.map {equalToWithoutDescription($0)})
 }
 
-func applyMatchers<T, S: Sequence>
-    (_ matchers: [Matcher<T>], values: S) -> MatchResult where S.Iterator.Element == T {
+func applyMatchers<T, S: Sequence>(_ matchers: [Matcher<T>], values: S) -> MatchResult where S.Iterator.Element == T {
     var mismatchDescriptions: [String?] = []
 
     var i = 0

--- a/Hamcrest/SequenceMatchers.swift
+++ b/Hamcrest/SequenceMatchers.swift
@@ -3,8 +3,7 @@ public func empty<T: Collection>() -> Matcher<T> {
 }
 
 public func hasCount<T: Collection>(_ matcher: Matcher<T.IndexDistance>) -> Matcher<T> {
-    return Matcher("has count " + matcher.description) {
-        (value: T) -> MatchResult in
+    return Matcher("has count " + matcher.description) { (value: T) -> MatchResult in
         let n = value.count
         return delegateMatching(n, matcher) {
             return "count " + describeActualValue(n, $0)
@@ -17,12 +16,10 @@ public func hasCount<T: Collection>(_ expectedCount: T.IndexDistance) -> Matcher
 }
 
 public func everyItem<T, S: Sequence>(_ matcher: Matcher<T>) -> Matcher<S> where S.Iterator.Element == T {
-    return Matcher("a sequence where every item \(matcher.description)") {
-        (values: S) -> MatchResult in
+    return Matcher("a sequence where every item \(matcher.description)") { (values: S) -> MatchResult in
         var mismatchDescriptions: [String?] = []
         for value in values {
-            switch delegateMatching(value, matcher, {
-                (mismatchDescription: String?) -> String? in
+            switch delegateMatching(value, matcher, { (mismatchDescription: String?) -> String? in
                 "mismatch: \(value)" + (mismatchDescription.map {" (\($0))"} ?? "")
             }) {
             case let .mismatch(mismatchDescription):
@@ -45,8 +42,8 @@ private func hasItem<T, S: Sequence>(_ matcher: Matcher<T>, _ values: S) -> Bool
 }
 
 public func hasItem<T, S: Sequence>(_ matcher: Matcher<T>) -> Matcher<S> where S.Iterator.Element == T {
-    return Matcher("a sequence containing \(matcher.description)") {
-        (values: S) -> Bool in hasItem(matcher, values)
+    return Matcher("a sequence containing \(matcher.description)") { (values: S) -> Bool in
+        hasItem(matcher, values)
     }
 }
 
@@ -55,8 +52,7 @@ public func hasItem<T: Equatable, S: Sequence>(_ expectedValue: T) -> Matcher<S>
 }
 
 private func hasItems<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
-    return Matcher("a sequence containing \(joinMatcherDescriptions(matchers))") {
-        (values: S) -> MatchResult in
+    return Matcher("a sequence containing \(joinMatcherDescriptions(matchers))") { (values: S) -> MatchResult in
         var missingItems = [] as [Matcher<T>]
         for matcher in matchers {
             if !hasItem(matcher, values) {
@@ -83,8 +79,7 @@ public func hasItems<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Match
 }
 
 private func contains<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
-    return Matcher("a sequence containing " + joinDescriptions(matchers.map({$0.description}))) {
-        (values: S) -> MatchResult in
+    return Matcher("a sequence containing " + joinDescriptions(matchers.map({$0.description}))) { (values: S) -> MatchResult in
         return applyMatchers(matchers, values: values)
     }
 }
@@ -100,9 +95,7 @@ public func contains<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Match
 private func containsInAnyOrder<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
     let descriptions = joinDescriptions(matchers.map({$0.description}))
 
-    return Matcher("a sequence containing in any order " + descriptions) {
-        (values: S) -> MatchResult in
-
+    return Matcher("a sequence containing in any order " + descriptions) { (values: S) -> MatchResult in
         var unmatchedValues: [T] = []
         var remainingMatchers = matchers
 

--- a/Hamcrest/StringMatchers.swift
+++ b/Hamcrest/StringMatchers.swift
@@ -5,8 +5,7 @@ public func containsString(_ string: String) -> Matcher<String> {
 }
 
 public func containsStringsInOrder(_ strings: String...) -> Matcher<String> {
-    return Matcher("contains in order \(describe(strings))") {
-        (value: String) -> Bool in
+    return Matcher("contains in order \(describe(strings))") { (value: String) -> Bool in
         var range = value.startIndex..<value.endIndex
         for string in strings {
             let r = value.range(of: string, options: .caseInsensitive, range: range)
@@ -34,8 +33,7 @@ public func matchesPattern(_ pattern: String, options: NSRegularExpression.Optio
 }
 
 public func matchesPattern(_ regularExpression: NSRegularExpression) -> Matcher<String> {
-    return Matcher("matches \(describe(regularExpression.pattern))") {
-        (value: String) -> Bool in
+    return Matcher("matches \(describe(regularExpression.pattern))") { (value: String) -> Bool in
         let range = NSMakeRange(0, (value as NSString).length)
         return regularExpression.numberOfMatches(in: value, options: [], range: range) > 0
     }


### PR DESCRIPTION
Not SwiftFormat this time. Swift formatting has become more uniform. This brings the code into established norms for where line breaks go.