### PR TITLE
Fix build error when there is a space in the project path

### DIFF
--- a/Hamcrest.xcodeproj/project.pbxproj
+++ b/Hamcrest.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
+			shellScript = "\"${SRCROOT}/bin/swiftformat\" --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void \"${SRCROOT}\"\n";
 		};
 		481906251ED69B6500E47930 /* Swift Format */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -441,7 +441,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/swiftformat --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void ${SRCROOT}\n";
+			shellScript = "\"${SRCROOT}/bin/swiftformat\" --disable indent,numberFormatting,ranges,redundantReturn,spaceAroundOperators,spaceInsideBraces,strongOutlets,trailingCommas,unusedArguments,void \"${SRCROOT}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Quote {SRCROT} in SwiftFormat build phase to support project path containing spaces.