### PR TITLE
Added assertNotThrows function

### DIFF
--- a/Hamcrest.xcodeproj/project.pbxproj
+++ b/Hamcrest.xcodeproj/project.pbxproj
@@ -94,7 +94,7 @@
 		244ABFE91B812A44007E8578 /* OperatorMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorMatcherTests.swift; sourceTree = "<group>"; };
 		245174F51B8139DF0031BDE1 /* MatchResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatchResultTests.swift; sourceTree = "<group>"; };
 		247C43341B4DD0D700F357B8 /* HamcrestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HamcrestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2484A1611AD6897F00076A3F /* README.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = README.playground; sourceTree = "<group>"; };
+		2484A1611AD6897F00076A3F /* README.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = README.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		248CDCB019A24B3500743F70 /* ReflectionMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReflectionMatcherTests.swift; sourceTree = "<group>"; };
 		248CDCB219A2531500743F70 /* StringMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringMatcherTests.swift; sourceTree = "<group>"; };
 		248CDCB419A2540200743F70 /* ArithmeticMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArithmeticMatcherTests.swift; sourceTree = "<group>"; };
@@ -108,7 +108,7 @@
 		2496DAFF19922407008C270E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2496DB0019922407008C270E /* MetaMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaMatcherTests.swift; sourceTree = "<group>"; };
 		2496DB0A19922429008C270E /* Hamcrest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hamcrest.swift; sourceTree = "<group>"; };
-		2496DB0C1992246B008C270E /* Playground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Playground.playground; sourceTree = "<group>"; };
+		2496DB0C1992246B008C270E /* Playground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Playground.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		24C73EBA19B7AA280096DCB7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		24D9341B19A23BED00A411BD /* DictionaryMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryMatcherTests.swift; sourceTree = "<group>"; };
 		24D9341D19A23DC200A411BD /* SequenceMatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceMatcherTests.swift; sourceTree = "<group>"; };

--- a/Hamcrest/Descriptions.swift
+++ b/Hamcrest/Descriptions.swift
@@ -30,6 +30,10 @@ func describeErrorMismatch<T>(_ error: T, _ description: String, _ mismatchDescr
     return "GOT ERROR: " + describeActualValue(error, mismatchDescription) + ", EXPECTED ERROR: \(description)"
 }
 
+func describeUnexpectedError() -> String {
+    return "UNEXPECTED ERROR"
+}
+
 public func describeMismatch<T>(_ value: T, _ description: String, _ mismatchDescription: String?) -> String {
     return "GOT: " + describeActualValue(value, mismatchDescription) + ", EXPECTED: \(description)"
 }

--- a/Hamcrest/Hamcrest.swift
+++ b/Hamcrest/Hamcrest.swift
@@ -72,6 +72,17 @@ func isPlayground() -> Bool {
     }
 }
 
+// MARK: assertNotThrows
+
+@discardableResult public func assertNotThrows<T>(_ value: @autoclosure () throws -> T, file: StaticString = #file, line: UInt = #line) -> String {
+    do {
+        _ = try value()
+        return reportResult(nil, file: file, line: line)
+    } catch {
+        return reportResult(describeUnexpectedError(), file: file, line: line)
+    }
+}
+
 // MARK: assertThat
 
 @discardableResult public func assertThat<T>(_ value: @autoclosure () throws -> T, _ matcher: Matcher<T>, file: StaticString = #file, line: UInt = #line) -> String {

--- a/Hamcrest/README.playground/Contents.swift
+++ b/Hamcrest/README.playground/Contents.swift
@@ -230,10 +230,15 @@ private func throwingFunc() throws -> Int {
 
 assertThat(try throwingFunc(), equalTo(1))
 
-//: If you want to verify an error is being thrown, use `assertThrows`.
+//: If you don't want to test the result of a function that can throw errors, or if this function does not return any error, use `assertNotThrows`.
 
 private func notThrowingFunc() throws {
 }
+
+assertNotThrows(try notThrowingFunc())
+assertNotThrows(_ = try throwingFunc())
+
+//: If you want to verify an error is being thrown, use `assertThrows`.
 
 assertThrows(try notThrowingFunc())
 assertThrows(try notThrowingFunc(), SampleError.Error2)

--- a/HamcrestTests/ErrorTests.swift
+++ b/HamcrestTests/ErrorTests.swift
@@ -75,6 +75,30 @@ class ErrorTests: BaseTestCase {
 
         assertReportsError("GOT ERROR: \(SampleError.error1), EXPECTED ERROR: equal to \(AlternativeError.error)")
     }
+
+    func testNotThrowingVoidFunc() {
+        assertNotThrows(try notThrowingVoidFunc())
+
+        assertReportsNoError()
+    }
+
+    func testNotThrowingVoidFuncWithError() {
+        assertNotThrows(try throwingVoidFunc())
+
+        assertReportsError("UNEXPECTED ERROR")
+    }
+
+    func testNotThrowingFunc() {
+        assertNotThrows(_ = try notThrowingFunc())
+
+        assertReportsNoError()
+    }
+
+    func testNotThrowingFuncWithError() {
+        assertNotThrows(_ = try throwingFunc())
+
+        assertReportsError("UNEXPECTED ERROR")
+    }
 }
 
 private enum SampleError: Error {

--- a/README.md
+++ b/README.md
@@ -323,11 +323,19 @@ private func throwingFunc() throws -> Int {
 assertThat(try throwingFunc(), equalTo(1)) // ERROR: SampleError.Error1
 ```
 
-If you want to verify an error is being thrown, use `assertThrows`.
+If you don't want to test the result of a function that can throw errors, or if this function does not return any error, use `assertNotThrows`.
 
 ```swift
 private func notThrowingFunc() throws {
 }
+
+assertNotThrows(try notThrowingFunc()) // ✓
+assertNotThrows(_ = try throwingFunc()) // ERROR: UNEXPECTED ERROR
+```
+
+If you want to verify an error is being thrown, use `assertThrows`.
+
+```swift
 
 assertThrows(try notThrowingFunc()) // EXPECTED ERROR
 assertThrows(try notThrowingFunc(), SampleError.Error2)


### PR DESCRIPTION
The `assertNotThrows` function is generating an error whenever the autoclosure passed to it is throwing an error.

This function is mainly written to test that a function is not throwing an error, without testing the returned value if there is one.
For the other cases, the `assertThat` function should be preferred.