### PR TITLE
Removed the exclusive option in the CocoaPods code block in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ Integrate SwiftHamcrest using a Podfile similar to this:
 ```ruby
 use_frameworks!
 
-target 'HamcrestDemoTests', :exclusive => true do
+target 'HamcrestDemoTests' do
+  inherit! :search_paths
   pod 'SwiftHamcrest', '~> 2.2.1'
 end
 ```


### PR DESCRIPTION
Removed the `:exclusive => true` part of the CocoaPods code block in the `README.md` file. The `exclusive` option has been replaced by the `inherit` option. See the "CocoaPods 1.0 Migration Guide" for more information (http://blog.cocoapods.org/CocoaPods-1.0-Migration-Guide).