### PR TITLE
Added a pod_target_xcconfig declaration in the SwiftHamcrest.podspec file

### DIFF
--- a/SwiftHamcrest.podspec
+++ b/SwiftHamcrest.podspec
@@ -21,4 +21,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/nschum/SwiftHamcrest.git", :tag => "2.2.1" }
   s.source_files = "Hamcrest/*.swift"
   s.frameworks   = ["Foundation", "XCTest"]
+
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+
 end


### PR DESCRIPTION
Added a `pod_target_xcconfig` declaration in the `SwiftHamcrest.podspec` file to change the `ENABLE_BITCODE` build setting to `NO`. Resolves #46.