### PR TITLE
Changed the `if let` and `guard let` syntax in three places to work in older versions of Xcode

### DIFF
--- a/Hamcrest/Hamcrest.swift
+++ b/Hamcrest/Hamcrest.swift
@@ -106,9 +106,9 @@ func isPlayground() -> Bool {
 
 func reportResult(_ possibleResult: String?, message: String? = nil, file: StaticString = #file, line: UInt = #line)
     -> String {
-    if let possibleResult {
+    if let possibleResult = possibleResult {
         let result: String
-        if let message {
+        if let message = message {
             result = "\(message) - \(possibleResult)"
         } else {
             result = possibleResult

--- a/HamcrestTests/AssertThatTests.swift
+++ b/HamcrestTests/AssertThatTests.swift
@@ -47,7 +47,7 @@ class AssertThatTests: BaseTestCase {
 
         assertThat(5, matcher, message: "Failure reason")
 
-        guard let reportedError else {
+        guard let reportedError = reportedError else {
             XCTFail("expected error")
             return
         }


### PR DESCRIPTION
I changed the `if let` and `guard let` syntax in three places so that the project compiles in Xcode 13.4.1 (i.e. Swift 5.6.1) and older versions of Xcode. This pull request fixes #52.