### PR TITLE
Make the `contains` matcher with an array parameter public.

### DIFF
--- a/Hamcrest/SequenceMatchers.swift
+++ b/Hamcrest/SequenceMatchers.swift
@@ -97,7 +97,7 @@ public func hasItems<T: Equatable, S: Sequence>(_ expectedValues: T...) -> Match
     return hasItems(expectedValues.map {equalToWithoutDescription($0)})
 }
 
-private func contains<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
+public func contains<T, S: Sequence>(_ matchers: [Matcher<T>]) -> Matcher<S> where S.Iterator.Element == T {
     return Matcher("a sequence containing " + joinDescriptions(matchers.map({$0.description}))) { (values: S) -> MatchResult in
         return applyMatchers(matchers, values: values)
     }


### PR DESCRIPTION
Motivation: Our codebase uses custom matchers that take in their own variadic parameters. Making this variant of the matcher public allows our custom matcher to forward its parameters to the newly-public matcher.